### PR TITLE
更新 webpack，在 dev 的时候把 i18n 复制到根目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 package.zip
 index.css
 index.js
+/i18n

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,6 +42,12 @@ module.exports = (env, argv) => {
                 return assetPath.replace("dist/", "");
             },
         }));
+    } else {
+        plugins.push(new CopyPlugin({
+            patterns: [
+                {from: "src/i18n/", to: "./i18n/"},
+            ],
+        }));
     }
     return {
         mode: argv.mode || "development",


### PR DESCRIPTION
官方推荐的流程是在插件目录开发，但是实际实践中，如果直接开发会发现无法运行插件。其中有一个原因就是在根目录下找不到 i18n。

这个 PR 修改了 webpack，使得在 dev 模式下自动拷贝 i18n。

同时更新了 gitignore，忽略根目录下的 i18n