### PR TITLE
Enhance SSE send format and expand file includes for .mts/.cts

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -5,7 +5,7 @@
   "useTabs": false,
   "newLineKind": "lf",
   "includes": [
-    "**/*.{ts,tsx,js,jsx,mjs,cjs}",
+    "**/*.{ts,tsx,js,jsx,mjs,cjs,mts,cts}",
     "**/*.{json,jsonc}",
     "**/*.{css,scss}",
     "**/*.{md,markdown}",
@@ -28,6 +28,7 @@
     "nextControlFlowPosition": "sameLine",
     "spaceSurroundingProperties": false,
     "importDeclaration.forceMultiLine": "whenMultiple",
+    "importDeclaration.spaceSurroundingNamedImports": false,
     "importDeclaration.sortNamedImports": "maintain"
   },
   "json": {

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -170,6 +170,11 @@ class KernelPlugin {
         );
 
         // ── siyuan.storage 示例
+
+        // 监听插件存储目录的文件系统事件。
+        // Watch filesystem events in the plugin storage directory.
+        await storage.watcher.add("./");
+
         // put：将 UTF-8 字符串写入相对于插件数据目录的路径。
         // put: write a UTF-8 string to a path relative to the plugin data dir.
         await storage.put("demo.txt", JSON.stringify(new Date().toISOString()));
@@ -391,7 +396,11 @@ class KernelPlugin {
      * After broadcasting, close any open client-side connections to avoid resource leaks in the kernel process.
      */
     private async onunload(): Promise<void> {
-        const {rpc, logger} = this.siyuan;
+        const {rpc, logger, storage} = this.siyuan;
+
+        // 解除对插件存储目录的文件系统事件的监听。
+        // Unwatch filesystem events in the plugin storage directory.
+        await storage.watcher.remove("./");
 
         // 解绑在 onload 中注册的 RPC 方法。
         // Unbind the RPC method registered in onload.

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -600,9 +600,8 @@ class KernelPlugin {
      * Demonstrates the SSE server handler at `GET /plugin/private/<name>/*path` (Server-Sent Events).
      *
      * `request.port.onopen` fires once the SSE stream is ready.
-     * Call `port.send(eventType, data)` inside `onopen` or later to push events.
-     * `eventType` maps to the SSE `event:` field.
-     * `data` maps to `data:`.
+     * Call `port.send(event)` inside `onopen` or later to push events.
+     *
      * `send` is synchronous.
      *
      * The connection stays open until `port.close()` is called or the client disconnects.

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -607,11 +607,16 @@ class KernelPlugin {
         request.port.onopen = async (event) => {
             await logger.debug("sse server: port open", event);
             // send 是同步的。
-            // eventType 会成为 SSE 的 `event:` 字段。
             // send is synchronous.
-            // eventType becomes the SSE `event:` field.
-            request.port.send("message", "Connected to plugin SSE!");
-            request.port.send("update", JSON.stringify({ts: Date.now()}));
+            request.port.send({
+                event: "update",
+                data: JSON.stringify({ts: Date.now()}),
+                id: Date.now().toString(),
+                retry: 5000,
+            });
+            request.port.send({
+                data: "Connected to plugin SSE!",
+            });
         };
         request.port.onclose = async (event) => {
             await logger.debug("sse server: port close", event);

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -617,10 +617,11 @@ class KernelPlugin {
             await logger.debug("sse server: port open", event);
             // send 是同步的。
             // send is synchronous.
+            const now = Date.now();
             request.port.send({
                 event: "update",
-                data: JSON.stringify({ts: Date.now()}),
-                id: Date.now().toString(),
+                data: JSON.stringify({ts: now}),
+                id: now.toString(),
                 retry: 5000,
             });
             request.port.send({


### PR DESCRIPTION
dprint.json: expand file includes to cover .mts and .cts files and set importDeclaration.spaceSurroundingNamedImports to false.

src/kernel.ts: change SSE port.send usage to the object form (including event, data, id, retry) for update events and send the connection message as a plain data payload. This adapts to the updated SSE send API/shape and ensures update events include an id and retry hint.